### PR TITLE
add release process scripts and docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
-# GitHub Actions 
+# Elementary GitHub Actions
 
 * [vala-lint](vala-lint/README.md) - Run vala-lint on your project.
+* [release](release/README.md) - Generate changelogs and push release tags to your project.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # elementary GitHub Actions
 
 * [vala-lint](vala-lint/README.md) - Run vala-lint on your project.
-* [release](release/README.md) - Generate changelogs and push release tags to your project.
+* [release](release/README.md) - Generate Debian changelogs, GitHub releases, and push release tags to your project.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Elementary GitHub Actions
+# elementary GitHub Actions
 
 * [vala-lint](vala-lint/README.md) - Run vala-lint on your project.
 * [release](release/README.md) - Generate changelogs and push release tags to your project.

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:stable-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y xmlstarlet curl git devscripts
+
+# create and use an elementary user instead of root
+RUN groupadd -r elementary && useradd --no-log-init -r -g elementary elementary
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/release/README.md
+++ b/release/README.md
@@ -31,7 +31,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
     - uses: elementary/actions/vala-lint@master
       with:
         dryrun: '--dry-run'
@@ -46,7 +46,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
     - uses: elementary/actions/vala-lint@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release/README.md
+++ b/release/README.md
@@ -48,10 +48,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
     steps:
     - uses: actions/checkout@v1
     - uses: elementary/actions/release@master
-      if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -67,10 +67,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
     steps:
     - uses: actions/checkout@v1
     - uses: elementary/actions/release@master
-      if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,66 @@
+# Release Action
+
+This action automates the manual steps needed to generate changelogs and push release tags.
+For more information on the overall flow of this ci image, take a look at the [elementary release process documentation](https://github.com/elementary/os/wiki/Release-Process).
+
+## Requirements
+
+This image is intended for use with elementary debian projects. There are a few requirements before getting started:
+
+  1. The project needs to have a deb-packaging branch with the necessary debian packaging for the project. Docs: [debian control](https://elementary.io/docs/code/getting-started#debian-control)
+  2. The project needs release information in an `appdata.xml` file. Docs: [appdata](https://elementary.io/docs/code/getting-started#appdata)
+
+### Environment Variables
+
+In order to create tags and push changes to various branches, the script needs a few environment variables set:
+
+| Environment Variable | Example Value                  |
+| :------------------- | :------------------------------|
+| GITHUB_TOKEN         | `abcd1234thisisanexampletoken` |
+| GIT_USER             | `exampleuser`                  |
+| GIT_EMAIL            | `example@somewhere.io`         |
+| GIT_KEY              | Contents of an id_rsa key.     |
+
+Keep in mind, when using github workflows, the virtual environment [automatically comes with a generated github token secret](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret).
+
+### Dry Run
+
+To test out the workflow and view information on what a project's changelog diffs would look like, you can use the dry-run option. For example:
+
+## Dry Run Example
+
+```yaml
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: elementary/actions/vala-lint@master
+      with:
+        dryrun: '--dry-run'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GIT_USER: "${{ secrets.GIT_USER }}"
+        GIT_EMAIL: "${{ secrets.GIT_EMAIL }}"
+        GIT_KEY: "${{ secrets.GIT_KEY }}"
+```
+
+## Full Example
+
+```yaml
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: elementary/actions/vala-lint@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GIT_USER: "${{ secrets.GIT_USER }}"
+        GIT_EMAIL: "${{ secrets.GIT_EMAIL }}"
+        GIT_KEY: "${{ secrets.GIT_KEY }}"
+```

--- a/release/README.md
+++ b/release/README.md
@@ -49,7 +49,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - uses: elementary/actions/release@master
       if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
       env:
@@ -68,7 +68,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - uses: elementary/actions/release@master
       if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
       env:

--- a/release/README.md
+++ b/release/README.md
@@ -23,17 +23,35 @@ with:
   release_branch: 'juno'
 ```
 
+### Specifying a label
+
+By default, the examples check for a label called `Release` on the related pull request. This can be set in the workflow action by changing the following:
+
+```yaml
+# check for "Release" label:
+true == contains(join(github.event.pull_request.labels.*.name), 'Release')
+# check for "Example" label:
+true == contains(join(github.event.pull_request.labels.*.name), 'Example')
+
+```
+
 ## Examples
 
 ### Simple Example
 
 ```yaml
+name: Release
+on:
+  pull_request:
+    branch: master
+    types: closed
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: elementary/actions/release@master
+      if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -41,14 +59,20 @@ jobs:
 ### Full Example
 
 ```yaml
+name: Release
+on:
+  pull_request:
+    branch: master
+    types: closed
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: elementary/actions/release@master
-      with:
-        release_branch: 'juno'
+      if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_branch: 'juno'
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -62,7 +62,7 @@ jobs:
 name: Release
 on:
   pull_request:
-    branch: master
+    branches: master
     types: closed
 jobs:
   release:

--- a/release/README.md
+++ b/release/README.md
@@ -12,13 +12,7 @@ This image is intended for use with elementary debian projects. There are a few 
 
 ### Environment Variables
 
-In order to create tags and push changes to various branches, the script needs a few environment variables set:
-
-| Environment Variable | Example Value                  |
-| :------------------- | :------------------------------|
-| GITHUB_TOKEN         | `abcd1234thisisanexampletoken` |
-
-Keep in mind, when using github workflows, the virtual environment [automatically comes with a generated github token secret](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret).
+In order to create tags and push changes to various branches, the script needs a github token. Keep in mind, when using github workflows, the virtual environment [automatically comes with a generated github token secret](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret).
 
 ### Dry Run
 
@@ -32,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: elementary/actions/vala-lint@master
+    - uses: elementary/actions/release@master
       with:
         dryrun: '--dry-run'
       env:
@@ -47,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: elementary/actions/vala-lint@master
+    - uses: elementary/actions/release@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -17,9 +17,6 @@ In order to create tags and push changes to various branches, the script needs a
 | Environment Variable | Example Value                  |
 | :------------------- | :------------------------------|
 | GITHUB_TOKEN         | `abcd1234thisisanexampletoken` |
-| GIT_USER             | `exampleuser`                  |
-| GIT_EMAIL            | `example@somewhere.io`         |
-| GIT_KEY              | Contents of an id_rsa key.     |
 
 Keep in mind, when using github workflows, the virtual environment [automatically comes with a generated github token secret](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret).
 
@@ -31,10 +28,8 @@ To test out the workflow and view information on what a project's changelog diff
 
 ```yaml
 jobs:
-  lint:
-
+  release:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - uses: elementary/actions/vala-lint@master
@@ -42,25 +37,17 @@ jobs:
         dryrun: '--dry-run'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_USER: "${{ secrets.GIT_USER }}"
-        GIT_EMAIL: "${{ secrets.GIT_EMAIL }}"
-        GIT_KEY: "${{ secrets.GIT_KEY }}"
 ```
 
 ## Full Example
 
 ```yaml
 jobs:
-  lint:
-
+  release:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - uses: elementary/actions/vala-lint@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_USER: "${{ secrets.GIT_USER }}"
-        GIT_EMAIL: "${{ secrets.GIT_EMAIL }}"
-        GIT_KEY: "${{ secrets.GIT_KEY }}"
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -14,11 +14,31 @@ This image is intended for use with elementary debian projects. There are a few 
 
 In order to create tags and push changes to various branches, the script needs a github token. Keep in mind, when using github workflows, the virtual environment [automatically comes with a generated github token secret](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret).
 
-### Dry Run
+### Specifying a release branch name
 
-To test out the workflow and view information on what a project's changelog diffs would look like, you can use the dry-run option. For example:
+By default, this action will create and update a branch named 'stable' whenever a release is pushed. The branch name can be set via the `release_branch` input. Example:
 
-## Dry Run Example
+```yaml
+with:
+  release_branch: 'juno'
+```
+
+## Examples
+
+### Simple Example
+
+```yaml
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: elementary/actions/release@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Full Example
 
 ```yaml
 jobs:
@@ -28,20 +48,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: elementary/actions/release@master
       with:
-        dryrun: '--dry-run'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-## Full Example
-
-```yaml
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: elementary/actions/release@master
+        release_branch: 'juno'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -43,7 +43,7 @@ true == contains(join(github.event.pull_request.labels.*.name), 'Example')
 name: Release
 on:
   pull_request:
-    branch: master
+    branches: master
     types: closed
 jobs:
   release:

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,0 +1,18 @@
+name: 'Release'
+description: 'Generate changelogs and publish new versions'
+inputs:
+  dryrun:
+    description: 'dry run option'
+    required: false
+    default: ''
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GIT_USER: "${{ secrets.GIT_USER }}"
+  GIT_EMAIL: "${{ secrets.GIT_EMAIL }}"
+  GIT_KEY: "${{ secrets.GIT_KEY }}"
+branding:
+  icon: 'git-pull-request'
+  color: 'green'

--- a/release/action.yml
+++ b/release/action.yml
@@ -8,8 +8,6 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 branding:
   icon: 'git-pull-request'
   color: 'green'

--- a/release/action.yml
+++ b/release/action.yml
@@ -10,9 +10,6 @@ runs:
   image: 'Dockerfile'
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GIT_USER: "${{ secrets.GIT_USER }}"
-  GIT_EMAIL: "${{ secrets.GIT_EMAIL }}"
-  GIT_KEY: "${{ secrets.GIT_KEY }}"
 branding:
   icon: 'git-pull-request'
   color: 'green'

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,10 +1,10 @@
 name: 'Release'
 description: 'Generate changelogs and publish new versions'
 inputs:
-  dryrun:
-    description: 'dry run option'
+  release_branch:
+    description: 'the name of the stable release branch'
     required: false
-    default: ''
+    default: 'stable'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -2,6 +2,8 @@
 set -e
 
 if [ "$1" != "--dry-run" ]; then
+  # make sure branches are up-to-date
+  git fetch
   echo "Setting up git credentials..."
   git remote set-url origin https://x-access-token:"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git
   git config --global user.email "action@github.com"
@@ -9,27 +11,8 @@ if [ "$1" != "--dry-run" ]; then
   echo "Git credentials configured."
 fi
 
-#------------------------#
-# Get Branch Information #
-#------------------------#
-
-# Checkout the branch that was merged into (eg. master).
-if [ -n "$GITHUB_REF" ]; then
-  BRANCH="$(basename"$GITHUB_REF")"
-else
-  BRANCH="master"
-fi
-echo "Checking out $BRANCH..."
-git checkout "$BRANCH"
-# Ensure that the local branch is exactly the same as the remote.
-git reset --hard origin/"$BRANCH"
-echo "$BRANCH checked out."
-
-# TODO: use the translations script to check for translation updates
-# update-translations
-
 # Check if this is a release branch that was merged in
-if ! git log --oneline  master -1 | grep "[release]"; then
+if ! git log --oneline -1 | grep -F "[release]" >/dev/null; then
   # not a release, nothing to do here.
   echo "not a release."
   exit 0
@@ -53,7 +36,7 @@ echo "Version: $VERSION"
 # get the release notes, remove any empty lines & padded spacing
 RELEASE_NOTE_RAW="$(xmlstarlet sel -t -v '//release[1]' -n data/"$APPDATA"| awk 'NF'| awk '{$1=$1}1')"
 echo "Release Note Content:"
-echo "$RELEASE_NOTE_RAW"
+echo -e "$RELEASE_NOTE_RAW\n"
 
 #-----------------------#
 # Create Github Release #
@@ -75,12 +58,11 @@ DATA="
 "
 
 if [ "$1" != "--dry-run" ]; then
-  echo -e "data contents:\n$DATA"
   # push the release content to github!
   if ! curl --data "$DATA" https://api.github.com/repos/"$GITHUB_REPOSITORY"/releases?access_token="$GITHUB_TOKEN"; then
     echo "\033[0;31mERROR: Unable to post github release tag information!\033[0m"  && exit 1
   fi
-  echo "A new github release tag has been created!"
+  echo -e "\n\033[1;32mA new github release tag has been created!\033[0m\n"
 else
   echo -e "curl contents:\ncurl --data $DATA https://api.github.com/repos/$GITHUB_REPOSITORY/releases?access_token=$GITHUB_TOKEN"
 fi
@@ -89,28 +71,38 @@ fi
 # Update Debian Changelog #
 #-------------------------#
 
+# make sure we are up to date on the master branch
+git checkout master
+git reset --hard origin/master
+
 # get all commit subjects since last tag
 COMMITS="$(git log "$(git describe --tags "$(git rev-list --tags --max-count=1)")"..HEAD --pretty="format:%s")"
 # filter out commits involving translations and commits that don't have a related merge number
 FILTERED_COMMITS="$(echo "$COMMITS" | awk '!/Weblate/' | awk '!/weblate/' | grep '(#')"
-# Get the first changelog entry
-FIRST_CHANGE="$(echo "$FILTERED_COMMITS" | head -n 1)"
 
 # move to the debian packaging branch
 if ! git checkout deb-packaging; then
   echo "\033[0;31mERROR: Unable to checkout the 'deb-packaging' branch. Does it exist?\033[0m" && exit 1
 fi
 
-# Create a versioned release and add the first line of the changelog
-dch -v "$VERSION" "$FIRST_CHANGE"
-# iterate over any other changelog entries, if there are any
-REMAINING_CHANGES="$(echo "$FILTERED_COMMITS"| tail -n +2)"
-if [ -n "$REMAINING_CHANGES" ]; then
-  while read -r line; do
-    # Append another list item to the changelog
-    dch -a "$line"
-  done <<< "$REMAINING_CHANGES"
+if [ -z "$FILTERED_COMMITS" ]; then
+  echo "no changes since last tag, an empty debian changelog will be created."
+  dch -v "$VERSION" "no changes since last release."
+else
+  # Get the first changelog entry
+  FIRST_CHANGE="$(echo "$FILTERED_COMMITS" | head -n 1)"
+  # Create a versioned release and add the first line of the changelog
+  dch -v "$VERSION" "$FIRST_CHANGE"
+  # iterate over any other changelog entries, if there are any
+  REMAINING_CHANGES="$(echo "$FILTERED_COMMITS"| tail -n +2)"
+  if [ -n "$REMAINING_CHANGES" ]; then
+    while read -r line; do
+      # Append another list item to the changelog
+      dch -a "$line"
+    done <<< "$REMAINING_CHANGES"
+  fi
 fi
+
 # Set the release channel/distro
 dch -r bionic
 
@@ -126,7 +118,7 @@ else
   if ! git push && git push origin "$TAG"; then
     echo "\033[0;31mERROR: Unable to push changelog information!\033[0m" && exit 1
   fi
-  echo "Changelogs have been pushed to deb-packaging!"
+  echo -e "\n\033[1;32mChangelogs have been pushed to deb-packaging!\033[0m\n"
 fi
 
 #------------------#
@@ -134,18 +126,23 @@ fi
 #------------------#
 
 if [ "$1" != "--dry-run" ]; then
+  # make sure we are up to date on the master branch before rebasing stable
+  git checkout master
+  git reset --hard origin/master
+
   # checkout or create stable branch
   if ! git show-ref --verify --quiet refs/heads/stable; then
     git checkout -b stable
   else
     git checkout stable
   fi
-  # rebase with master & push to remote
-  if ! git rebase master; then
+
+  # rebase off of master & push to remote
+  if ! git rebase origin/master; then
     echo "\033[0;31mERROR: Unable to merge master into stable!\033[0m" && exit 1
   fi
-  if ! git push origin stable; then
+  if ! git push origin stable --force-with-lease; then
     echo "\033[0;31mERROR: Unable to push changes to stable branch!\033[0m" && exit 1
   fi
-  echo "The stable branch has been updated successfully!"
+  echo -e "\n\033[1;32mThe stable branch has been updated successfully!\033[0m\n"
 fi

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -2,15 +2,10 @@
 set -e
 
 if [ "$1" != "--dry-run" ]; then
-  # Git Credential Setup
   echo "Setting up git credentials..."
-  git config --global user.email "$GIT_EMAIL"
-  git config --global user.name "$GIT_USER"
-  mkdir -p ~/.ssh
-  echo -e "Host github.com\\n\\tStrictHostKeyChecking no\\n\\tLogLevel ERROR\\n" >> ~/.ssh/config
-  echo -e "$GIT_KEY" > ~/.ssh/id_rsa
-  chmod 0400 ~/.ssh/id_rsa
-  git remote set-url origin git@github.com:"$GITHUB_REPOSITORY"
+  git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+  git config --global user.email "action@github.com"
+  git config --global user.name "GitHub Action"
   echo "Git credentials configured."
 fi
 

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 
 # Checkout the branch that was merged into (eg. master).
 if [ -n "$GITHUB_REF" ]; then
-  BRANCH="$GITHUB_REF"
+  BRANCH="$(basename"$GITHUB_REF")"
 else
   BRANCH="master"
 fi

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+set -e
+
+if [ "$1" != "--dry-run" ]; then
+  # Git Credential Setup
+  echo "Setting up git credentials..."
+  git config --global user.email "$GIT_EMAIL"
+  git config --global user.name "$GIT_USER"
+  mkdir -p ~/.ssh
+  echo -e "Host github.com\\n\\tStrictHostKeyChecking no\\n\\tLogLevel ERROR\\n" >> ~/.ssh/config
+  echo -e "$GIT_KEY" > ~/.ssh/id_rsa
+  chmod 0400 ~/.ssh/id_rsa
+  git remote set-url origin git@github.com:"$GITHUB_REPOSITORY"
+  echo "Git credentials configured."
+fi
+
+#------------------------#
+# Get Branch Information #
+#------------------------#
+
+# Checkout the branch that was merged into (eg. master).
+if [ -n "$GITHUB_REF" ]; then
+  BRANCH="$GITHUB_REF"
+else
+  BRANCH="master"
+fi
+echo "Checking out $BRANCH..."
+git checkout "$BRANCH"
+# Ensure that the local branch is exactly the same as the remote.
+git reset --hard origin/"$BRANCH"
+echo "$BRANCH checked out."
+
+# TODO: use the translations script to check for translation updates
+# update-translations
+
+# Check if this is a release branch that was merged in
+if ! git log --oneline  master -1 | grep "[release]"; then
+  # not a release, nothing to do here.
+  echo "not a release."
+  exit 0
+fi
+
+# get the project's name:
+PROJECT="$(basename "$GITHUB_REPOSITORY")"
+echo "Project: $PROJECT"
+
+#---------------#
+# Parse Appdata #
+#---------------#
+
+# get appdata filename:
+APPDATA="$(basename "$(find data -name "*appdata*")")"
+
+# get the version and release notes from the latest release entry in the appdata
+VERSION="$(xmlstarlet sel -t -v '//release[1]//@version' -n data/"$APPDATA")"
+echo "Version: $VERSION"
+
+# get the release notes, remove any empty lines & padded spacing
+RELEASE_NOTE_RAW="$(xmlstarlet sel -t -v '//release[1]' -n data/"$APPDATA"| awk 'NF'| awk '{$1=$1}1')"
+echo "Release Note Content:"
+echo "$RELEASE_NOTE_RAW"
+
+#-----------------------#
+# Create Github Release #
+#-----------------------#
+
+# add ul stars to the notes and replace any newlines with a newline character instead
+MARKDOWN_NOTES="$(echo "$RELEASE_NOTE_RAW" | awk '$0="* "$0' | awk '{printf "%s\\n", $0}')"
+# add the project name and version to release note
+GITHUB_RELEASE_NOTE="$PROJECT $VERSION is out! \n\nChanges:\n\n$MARKDOWN_NOTES"
+DATA="
+{
+  \"tag_name\": \"$VERSION\",
+  \"target_commitish\": \"master\",
+  \"name\": \"$PROJECT $VERSION Released\",
+  \"body\": \"$GITHUB_RELEASE_NOTE\",
+  \"draft\": false,
+  \"prerelease\": false
+}
+"
+
+if [ "$1" != "--dry-run" ]; then
+  echo -e "data contents:\n$DATA"
+  # push the release content to github!
+  if ! curl --data "$DATA" https://api.github.com/repos/"$GITHUB_REPOSITORY"/releases?access_token="$GITHUB_TOKEN"; then
+    echo "\033[0;31mERROR: Unable to post github release tag information!\033[0m"  && exit 1
+  fi
+  echo "A new github release tag has been created!"
+else
+  echo -e "curl contents:\ncurl --data $DATA https://api.github.com/repos/$GITHUB_REPOSITORY/releases?access_token=$GITHUB_TOKEN"
+fi
+
+#-------------------------#
+# Update Debian Changelog #
+#-------------------------#
+
+# get all commit subjects since last tag
+COMMITS="$(git log "$(git describe --tags "$(git rev-list --tags --max-count=1)")"..HEAD --pretty="format:%s")"
+# filter out commits involving translations and commits that don't have a related merge number
+FILTERED_COMMITS="$(echo "$COMMITS" | awk '!/Weblate/' | awk '!/weblate/' | grep '(#')"
+# Get the first changelog entry
+FIRST_CHANGE="$(echo "$FILTERED_COMMITS" | head -n 1)"
+
+# move to the debian packaging branch
+if ! git checkout deb-packaging; then
+  echo "\033[0;31mERROR: Unable to checkout the 'deb-packaging' branch. Does it exist?\033[0m" && exit 1
+fi
+
+# Create a versioned release and add the first line of the changelog
+dch -v "$VERSION" "$FIRST_CHANGE"
+# iterate over any other changelog entries, if there are any
+REMAINING_CHANGES="$(echo "$FILTERED_COMMITS"| tail -n +2)"
+if [ -n "$REMAINING_CHANGES" ]; then
+  while read -r line; do
+    # Append another list item to the changelog
+    dch -a "$line"
+  done <<< "$REMAINING_CHANGES"
+fi
+# Set the release channel/distro
+dch -r bionic
+
+# Commit, Tag, and Push
+if [ "$1" == "--dry-run" ]; then
+  echo "deb-packaging changelog diff:"
+  git diff
+else
+  TAG="$VERSION-debian"
+  if ! git commit -am "Release $VERSION" && git tag -a "$TAG" -m "$TAG"; then
+    echo "\033[0;31mERROR: Unable to commit and tag changelog information!\033[0m" && exit 1
+  fi
+  if ! git push && git push origin "$TAG"; then
+    echo "\033[0;31mERROR: Unable to push changelog information!\033[0m" && exit 1
+  fi
+  echo "Changelogs have been pushed to deb-packaging!"
+fi
+
+#------------------#
+# Deploy to stable #
+#------------------#
+
+if [ "$1" != "--dry-run" ]; then
+  # checkout or create stable branch
+  if ! git show-ref --verify --quiet refs/heads/stable; then
+    git checkout -b stable
+  else
+    git checkout stable
+  fi
+  # rebase with master & push to remote
+  if ! git rebase master; then
+    echo "\033[0;31mERROR: Unable to merge master into stable!\033[0m" && exit 1
+  fi
+  if ! git push origin stable; then
+    echo "\033[0;31mERROR: Unable to push changes to stable branch!\033[0m" && exit 1
+  fi
+  echo "The stable branch has been updated successfully!"
+fi

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [ -z "${GITHUB_TOKEN}" ]; then
+  echo "\033[0;31mERROR: The GITHUB_TOKEN environment variable is not defined.\033[0m"  && exit 1
+fi
+
 if [ -z "$1" ]; then
   RELEASE_BRANCH="stable"
 else
@@ -14,13 +18,6 @@ git remote set-url origin https://x-access-token:"$GITHUB_TOKEN"@github.com/"$GI
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"
 echo "Git credentials configured."
-
-# Check if this is a release branch that was merged in
-if ! git log --oneline -1 | grep -F "[release]" >/dev/null; then
-  # not a release, nothing to do here.
-  echo "not a release."
-  exit 0
-fi
 
 # get the project's name:
 PROJECT="$(basename "$GITHUB_REPOSITORY")"

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -50,7 +50,7 @@ GITHUB_RELEASE_NOTE="$PROJECT $VERSION is out! \n\nChanges:\n\n$MARKDOWN_NOTES"
 DATA="
 {
   \"tag_name\": \"$VERSION\",
-  \"target_commitish\": \"master\",
+  \"target_commitish\": \"$GITHUB_SHA\",
   \"name\": \"$PROJECT $VERSION Released\",
   \"body\": \"$GITHUB_RELEASE_NOTE\",
   \"draft\": false,

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ "$1" != "--dry-run" ]; then
   echo "Setting up git credentials..."
-  git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+  git remote set-url origin https://x-access-token:"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git
   git config --global user.email "action@github.com"
   git config --global user.name "GitHub Action"
   echo "Git credentials configured."

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -68,9 +68,8 @@ echo -e "\n\033[1;32mA new github release tag has been created!\033[0m\n"
 # Update Debian Changelog #
 #-------------------------#
 
-# make sure we are up to date on the master branch
-git checkout master
-git reset --hard origin/master
+# make sure we are in sync with HEAD
+git reset --hard HEAD
 
 # get all commit subjects since last tag
 COMMITS="$(git log "$(git describe --tags "$(git rev-list --tags --max-count=1)")"..HEAD --pretty="format:%s")"
@@ -84,24 +83,24 @@ fi
 
 if [ -z "$FILTERED_COMMITS" ]; then
   echo "no changes since last tag, an empty debian changelog will be created."
-  dch -v "$VERSION" "no changes since last release."
+  dch -mv "$VERSION" "no changes since last release."
 else
   # Get the first changelog entry
   FIRST_CHANGE="$(echo "$FILTERED_COMMITS" | head -n 1)"
   # Create a versioned release and add the first line of the changelog
-  dch -v "$VERSION" "$FIRST_CHANGE"
+  dch -mv "$VERSION" "$FIRST_CHANGE"
   # iterate over any other changelog entries, if there are any
   REMAINING_CHANGES="$(echo "$FILTERED_COMMITS"| tail -n +2)"
   if [ -n "$REMAINING_CHANGES" ]; then
     while read -r line; do
       # Append another list item to the changelog
-      dch -a "$line"
+      dch -ma "$line"
     done <<< "$REMAINING_CHANGES"
   fi
 fi
 
 # Set the release channel/distro
-dch -r bionic
+dch -mr bionic
 
 # Commit, Tag, and Push
 TAG="$VERSION-debian"
@@ -117,9 +116,9 @@ echo -e "\n\033[1;32mChangelogs have been pushed to deb-packaging!\033[0m\n"
 # Deploy to stable #
 #------------------#
 
-# make sure we are up to date on the master branch before rebasing stable
-git checkout master
-git reset --hard origin/master
+# point head back to what it was before checking out deb-packaging
+git checkout -
+git reset --hard HEAD
 
 # checkout or create stable branch
 if ! git show-ref --verify --quiet refs/heads/"$RELEASE_BRANCH"; then

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -36,15 +36,18 @@ echo "Version: $VERSION"
 
 # get the release notes, remove any empty lines & padded spacing
 RELEASE_NOTE_RAW="$(xmlstarlet sel -t -v '//release[1]' -n data/"$APPDATA"| awk 'NF'| awk '{$1=$1}1')"
+# replace quotes with commented quotes to prevent breakage in github release note string
+RELEASE_NOTES_SANITIZED="${RELEASE_NOTE_RAW//\"/\\\"}"
 echo "Release Note Content:"
-echo -e "$RELEASE_NOTE_RAW\n"
+echo -e "$RELEASE_NOTES_SANITIZED\n"
+
 
 #-----------------------#
 # Create Github Release #
 #-----------------------#
 
 # add ul stars to the notes and replace any newlines with a newline character instead
-MARKDOWN_NOTES="$(echo "$RELEASE_NOTE_RAW" | awk '$0="* "$0' | awk '{printf "%s\\n", $0}')"
+MARKDOWN_NOTES="$(echo "$RELEASE_NOTES_SANITIZED" | awk '$0="* "$0' | awk '{printf "%s\\n", $0}')"
 # add the project name and version to release note
 GITHUB_RELEASE_NOTE="$PROJECT $VERSION is out! \n\nChanges:\n\n$MARKDOWN_NOTES"
 DATA="

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -83,24 +83,24 @@ fi
 
 if [ -z "$FILTERED_COMMITS" ]; then
   echo "no changes since last tag, an empty debian changelog will be created."
-  dch -mv "$VERSION" "no changes since last release."
+  dch -Mv "$VERSION" "no changes since last release."
 else
   # Get the first changelog entry
   FIRST_CHANGE="$(echo "$FILTERED_COMMITS" | head -n 1)"
   # Create a versioned release and add the first line of the changelog
-  dch -mv "$VERSION" "$FIRST_CHANGE"
+  dch -Mv "$VERSION" "$FIRST_CHANGE"
   # iterate over any other changelog entries, if there are any
   REMAINING_CHANGES="$(echo "$FILTERED_COMMITS"| tail -n +2)"
   if [ -n "$REMAINING_CHANGES" ]; then
     while read -r line; do
       # Append another list item to the changelog
-      dch -ma "$line"
+      dch -Ma "$line"
     done <<< "$REMAINING_CHANGES"
   fi
 fi
 
 # Set the release channel/distro
-dch -mr bionic
+dch -Mr bionic
 
 # Commit, Tag, and Push
 TAG="$VERSION-debian"


### PR DESCRIPTION
This should add the automated steps required for the documented [release process](https://github.com/elementary/os/wiki/Release-Process).

## Pipeline Runs:
https://github.com/kgrubb/helloworld/commit/fc646ddac60f2e496f3fd16dcd413ddb0fcb2b39/checks?check_suite_id=271628225

https://github.com/kgrubb/helloworld/commit/24d913f9caa3fde682cf456b01882f3e965d9b87/checks?check_suite_id=271663391

## Example Output:

* __github release:__ https://github.com/kgrubb/helloworld/releases/tag/1.1.0
* __debian changelog:__ https://github.com/kgrubb/helloworld/blob/deb-packaging/debian/changelog
* __stable branch:__ https://github.com/kgrubb/helloworld/tree/stable
* __ci run:__ https://github.com/kgrubb/helloworld/commit/24d913f9caa3fde682cf456b01882f3e965d9b87/checks?check_suite_id=271663391