### PR TITLE
pass release_branch into script args

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -8,6 +8,8 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.release_branch }}
 branding:
   icon: 'git-pull-request'
   color: 'green'


### PR DESCRIPTION
In the [release ci run for initial-setup](https://github.com/elementary/initial-setup/commit/f00e01ba9324afc0510e872c1f0b69aed13af413/checks?check_suite_id=274711859), the "stable" branch was pushed to instead of the `juno` branch even though `juno` was explicitly set. This was because the entrypoint script didn't get the inputs as an arg. This fixes the issue by passing the release_branch input as the first arg of `entrypoint.sh`