### PR TITLE
use different method for finding last version tag

### DIFF
--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -87,7 +87,7 @@ echo -e "\n\033[1;32mA new github release tag has been created!\033[0m\n"
 git reset --hard HEAD
 
 # get all commit subjects since last tag
-COMMITS="$(git log "$(git describe --tags "$(git rev-list --tags --max-count=1)")"..HEAD --pretty="format:%s")"
+COMMITS="$(git log "$(git tag -l '*-debian' | tail -n1 | cut -d'-' -f 1)"..HEAD --pretty="format:%s")"
 # filter out commits involving translations and commits that don't have a related merge number
 FILTERED_COMMITS="$(echo "$COMMITS" | awk '!/Weblate/' | awk '!/weblate/' | grep '(#')"
 


### PR DESCRIPTION
The old format would get the last tag, which was getting the debian version tag, causing an incorrect list of commits. :cry:

This change searches git tags by the last `-debian` tag and then cuts the `-debian` label, to get the last version tag.

There may be a prettier way to do this? I'm not sure. :thinking: 

Here's an example of the messed up changelog info:
https://github.com/kgrubb/helloworld/commit/3910e5f2d4b6a02a2ebc1b0e648a747f045d199b

Here's an example of the fixed changelog info from using the changes in this branch:
https://github.com/kgrubb/helloworld/commit/817dfc11bd10cd17b36b17bb48efacf0db57099a