### PR TITLE
fix commit filter for debian changelog

### DIFF
--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -46,6 +46,9 @@ APPDATA="$(basename "$(find data -name "*appdata*")")"
 VERSION="$(xmlstarlet sel -t -v '//release[1]//@version' -n data/"$APPDATA")"
 echo "Version: $VERSION"
 
+# get the last version tag before we create a new one!
+PREVIOUS_VERSION="$(git tag -l | grep -v 'debian' | tail -n1 )"
+
 # get the release notes, remove any empty lines & padded spacing
 RELEASE_NOTE_RAW="$(xmlstarlet sel -t -v '//release[1]' -n data/"$APPDATA"| awk 'NF'| awk '{$1=$1}1')"
 # replace quotes with commented quotes to prevent breakage in github release note string
@@ -86,10 +89,13 @@ echo -e "\n\033[1;32mA new github release tag has been created!\033[0m\n"
 # make sure we are in sync with HEAD
 git reset --hard HEAD
 
-# get all commit subjects since last tag
-COMMITS="$(git log "$(git tag -l '*-debian' | tail -n1 | cut -d'-' -f 1)"..HEAD --pretty="format:%s")"
+# get all commit subjects since previous version tag
+COMMITS="$(git log "$PREVIOUS_VERSION"..HEAD --pretty="format:%s")"
 # filter out commits involving translations and commits that don't have a related merge number
-FILTERED_COMMITS="$(echo "$COMMITS" | awk '!/Weblate/' | awk '!/weblate/' | grep '(#')"
+FILTERED_COMMITS="$(echo "$COMMITS" | grep -v 'Weblate' | grep -v 'weblate')"
+
+echo "Debian Changelog Content:"
+echo -e "$FILTERED_COMMITS\n"
 
 # move to the debian packaging branch
 if ! git checkout deb-packaging; then


### PR DESCRIPTION
## TODO:

* [x] make sure a release with no changes posts "no changes"

* [x] make sure a release with changes lists each commit in the debian changelog (minus weblate and merge commits)

## Changes:

* Move tag check up, before the github release tag is created

* use grep instead of awk in the commit filters, since awk was causing a `1` exit code, killing the pipeline. 

* add debian changelog contents to ci run, to make them available for view in the event of a failed pipeline run.


Pipeline in action:
https://github.com/kgrubb/helloworld/commit/8e44a56456b7a6f112c3549869ba75cfbd6d2944/checks?check_suite_id=282013568

Here's another debian changelog with more than just the release merge:
https://github.com/kgrubb/helloworld/commit/17d3e4666456ee452f9a183bda6321a0ad91e466