### PR TITLE
allow html instead of forcing a bulleted list for release note co…

### DIFF
--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -63,7 +63,7 @@ echo -e "$RELEASE_NOTES_SANITIZED\n"
 # replace newlines with a newline character
 MARKDOWN_NOTES="$(echo "$RELEASE_NOTES_SANITIZED" | awk '{printf "%s\\n", $0}')"
 # add the project name and version to release note
-GITHUB_RELEASE_NOTE="$PROJECT $VERSION is out! \n\nChanges:\n\n$MARKDOWN_NOTES"
+GITHUB_RELEASE_NOTE="$PROJECT $VERSION is out! \n\n$MARKDOWN_NOTES"
 DATA="
 {
   \"tag_name\": \"$VERSION\",

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -50,19 +50,18 @@ echo "Version: $VERSION"
 PREVIOUS_VERSION="$(git tag -l | grep -v 'debian' | tail -n1 )"
 
 # get the release notes, remove any empty lines & padded spacing
-RELEASE_NOTE_RAW="$(xmlstarlet sel -t -v '//release[1]' -n data/"$APPDATA"| awk 'NF'| awk '{$1=$1}1')"
+RELEASE_NOTE_RAW="$(xmlstarlet sel -t -m '//release[1]/description/*' -n -c '.' -n data/"$APPDATA" | awk 'NF' | awk '{$1=$1}1')"
 # replace quotes with commented quotes to prevent breakage in github release note string
 RELEASE_NOTES_SANITIZED="${RELEASE_NOTE_RAW//\"/\\\"}"
 echo "Release Note Content:"
 echo -e "$RELEASE_NOTES_SANITIZED\n"
 
-
 #-----------------------#
 # Create Github Release #
 #-----------------------#
 
-# add ul stars to the notes and replace any newlines with a newline character instead
-MARKDOWN_NOTES="$(echo "$RELEASE_NOTES_SANITIZED" | awk '$0="* "$0' | awk '{printf "%s\\n", $0}')"
+# replace newlines with a newline character
+MARKDOWN_NOTES="$(echo "$RELEASE_NOTES_SANITIZED" | awk '{printf "%s\\n", $0}')"
 # add the project name and version to release note
 GITHUB_RELEASE_NOTE="$PROJECT $VERSION is out! \n\nChanges:\n\n$MARKDOWN_NOTES"
 DATA="


### PR DESCRIPTION
# Changes:

* Release descriptions with html content that isn't a bulleted list will now show properly

# Examples:

ci run: https://github.com/kgrubb/helloworld/commit/a4d9992f85f57dcac59fbb62fde6d122690b0c77/checks?check_suite_id=328210306

release content: https://github.com/kgrubb/helloworld/releases/tag/1.5.1

screenshot:
<img width="412" alt="Screen Shot 2019-11-25 at 3 27 05 PM" src="https://user-images.githubusercontent.com/8471701/69575421-3103ce00-0f98-11ea-934c-2589d7384ca3.png">

