### PR TITLE
gettext: Avoid apt command being stuck with tzdata

### DIFF
--- a/gettext-template/Dockerfile
+++ b/gettext-template/Dockerfile
@@ -2,7 +2,7 @@ FROM elementary/docker:unstable
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y devscripts equivs meson git python3-git libxml2-utils appstream policykit-1 sudo
+RUN apt-get -qq update && apt-get install -qq devscripts equivs meson git python3-git libxml2-utils appstream policykit-1 sudo tzdata
 
 RUN groupadd -r elementary && useradd --no-log-init -r -g elementary elementary
 

--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -53,8 +53,8 @@ if ! git checkout deb-packaging; then
 fi
 
 # Create a fake package depending on the build dependency and install/remove it
-sudo apt -y update
-mk-build-deps --build-dep --install --remove --tool 'apt -y' --root-cmd sudo debian/control
+sudo apt-get -qq update
+mk-build-deps --build-dep --install --remove --tool 'apt-get -qq' --root-cmd sudo debian/control
 
 echo -e "\n\033[1;32mInstalled all the build dependencies!\033[0m\n"
 


### PR DESCRIPTION
Use apt-get instead of apt as it is not recommended for command lines for now.