### PR TITLE
remove foo x.y.z is out!

### DIFF
--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -60,10 +60,8 @@ echo -e "$RELEASE_NOTES_SANITIZED\n"
 # Create Github Release #
 #-----------------------#
 
-# replace newlines with a newline character
-MARKDOWN_NOTES="$(echo "$RELEASE_NOTES_SANITIZED" | awk '{printf "%s\\n", $0}')"
-# add the project name and version to release note
-GITHUB_RELEASE_NOTE="$PROJECT $VERSION is out! \n\n$MARKDOWN_NOTES"
+# replace newlines with a newline character & add the project name and version to release note
+GITHUB_RELEASE_NOTE="$(echo "$RELEASE_NOTES_SANITIZED" | awk '{printf "%s\\n", $0}')"
 DATA="
 {
   \"tag_name\": \"$VERSION\",


### PR DESCRIPTION
remove "foo x.y.z is out!" in favor of just printing the release note contents directly. Fixes #35 