### PR TITLE
gettext: Always make sure to have a default keyboard configured, set extra variables to silence warnings

### DIFF
--- a/gettext-template/Dockerfile
+++ b/gettext-template/Dockerfile
@@ -1,8 +1,24 @@
 FROM elementary/docker:unstable
 
-ENV DEBIAN_FRONTEND=noninteractive
+# Generic apt configuration
 
-RUN apt-get -qq update && apt-get install -qq devscripts equivs meson git python3-git libxml2-utils appstream policykit-1 sudo tzdata
+ENV TERM dumb
+
+# apt config:  silence warnings and set defaults
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV LC_ALL C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LANG C.UTF-8
+
+# turn off recommends on container OS and proot OS
+RUN echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > \
+            /etc/apt/apt.conf.d/01norecommend && \
+    mkdir -p ${ROOTFS}/etc/apt/apt.conf.d && \
+    echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > \
+            ${ROOTFS}/etc/apt/apt.conf.d/01norecommend
+
+RUN apt-get -qq update && apt-get install -qq devscripts equivs meson git python3-git libxml2-utils appstream policykit-1 sudo tzdata keyboard-configuration
 
 RUN groupadd -r elementary && useradd --no-log-init -r -g elementary elementary
 


### PR DESCRIPTION
The goal is to fix https://github.com/elementary/installer that is failing