### PR TITLE
gettext-template: Do not require deb-packaging branch

### DIFF
--- a/gettext-template/README.md
+++ b/gettext-template/README.md
@@ -47,7 +47,11 @@ with:
 
 ## Install Dependencies
 
-If you need dependencies not included in the package `elementary-sdk`, you need to install manually by using the `dependencies` input. Example:
+If you need dependencies not included in the package `elementary-sdk` on build, you need to install them manually.
+
+This action automatically install dependencies listed in `debian/control` file in the `deb-packaging` branch if it exists.
+
+If your project doesn't have the `deb-packaging` branch, you can use the `dependencies` input. Example:
 
 ```yaml
 with:

--- a/gettext-template/README.md
+++ b/gettext-template/README.md
@@ -4,10 +4,7 @@ This action automates the manual steps needed to regenerate the gettext template
 
 ## Requirements
 
-This image is intended for use with elementary debian projects. There are a few requirements before getting started:
-
-  1. The project needs to have a deb-packaging branch with the necessary debian packaging for the project. Docs: [debian control](https://elementary.io/docs/code/getting-started#debian-control)
-  2. The project needs to use the meson build system
+This image is intended for use with elementary projects. The project needs to use the meson build system.
 
 ### Environment Variables
 
@@ -48,6 +45,15 @@ with:
   regenerate_po: 'true'
 ```
 
+## Install Dependencies
+
+If you need dependencies not included in the package `elementary-sdk`, you need to install manually by using the `dependencies` input. Example:
+
+```yaml
+with:
+  dependencies: 'libgtksourceview-4.0-dev libgstreamer1.0-dev'
+```
+
 ## Examples
 
 ### Simple Example
@@ -83,6 +89,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+        dependencies: 'libgtksourceview-4.0-dev'
         translation_branch: 'i18n'
         regenerate_po: 'true'
 ```

--- a/gettext-template/action.yml
+++ b/gettext-template/action.yml
@@ -1,6 +1,9 @@
 name: 'Gettext Auto-update'
 description: 'Push the new gettext template and translations when required'
 inputs:
+  dependencies:
+    description: 'Additional dependencies you need in your project, separated in a single space'
+    required: false
   github_token:
     description: 'Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
     required: true

--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -47,10 +47,9 @@ echo "Project: $PROJECT"
 
 # Install additional dependencies if provided
 if [ -n "$INPUT_DEPENDENCIES" ]; then
-  DEPS="$INPUT_DEPENDENCIES"
   sudo apt-get -qq update
   sudo apt-get -qq dist-upgrade
-  sudo apt-get install --no-install-recommends -qq $DEPS
+  sudo apt-get install --no-install-recommends -qq $INPUT_DEPENDENCIES
 fi
 
 #---------------------------------#

--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -55,14 +55,14 @@ sudo apt-get -qq dist-upgrade
 if git checkout deb-packaging; then
   sudo apt-get --no-install-recommends -qq build-dep .
   git checkout -
+  echo -e "\n\033[1;32mInstalled all the build dependencies!\033[0m\n"
+# if deb-packaging branch does not exist, try to install provided dependencies as an input
+elif [ -n "$INPUT_DEPENDENCIES" ]; then
+  sudo apt-get install --no-install-recommends -qq $INPUT_DEPENDENCIES
+  echo -e "\n\033[1;32mInstalled all the build dependencies!\033[0m\n"
 else
-  # if deb-packaging branch does not exist, install provided dependencies as an input
-  if [ -n "$INPUT_DEPENDENCIES" ]; then
-    sudo apt-get install --no-install-recommends -qq $INPUT_DEPENDENCIES
-  fi
+  echo -e "\n\033[1;32mNo additional dependencies provided.\033[0m\n"
 fi
-
-echo -e "\n\033[1;32mInstalled all the build dependencies!\033[0m\n"
 
 #---------------------------------#
 # Update the translation template #

--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -45,18 +45,30 @@ echo "Project: $PROJECT"
 # Install the build dependencies #
 #--------------------------------#
 
-# Install additional dependencies if provided
-if [ -n "$INPUT_DEPENDENCIES" ]; then
-  sudo apt-get -qq update
-  sudo apt-get -qq dist-upgrade
-  sudo apt-get install --no-install-recommends -qq $INPUT_DEPENDENCIES
+# make sure we are in sync with HEAD
+git reset --hard HEAD
+
+sudo apt-get -qq update
+sudo apt-get -qq dist-upgrade
+
+# move to the debian packaging branch
+if git checkout deb-packaging; then
+  sudo apt-get --no-install-recommends -qq build-dep .
+  git checkout -
+else
+  # if deb-packaging branch does not exist, install provided dependencies as an input
+  if [ -n "$INPUT_DEPENDENCIES" ]; then
+    sudo apt-get install --no-install-recommends -qq $INPUT_DEPENDENCIES
+  fi
 fi
+
+echo -e "\n\033[1;32mInstalled all the build dependencies!\033[0m\n"
 
 #---------------------------------#
 # Update the translation template #
 #---------------------------------#
 
-# make sure we are in sync with HEAD
+# point head back to what it was before checking out deb-packaging
 git reset --hard HEAD
 
 if ! git checkout $TRANSLATION_BRANCH; then

--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -45,26 +45,19 @@ echo "Project: $PROJECT"
 # Install the build dependencies #
 #--------------------------------#
 
-# make sure we are in sync with HEAD
-git reset --hard HEAD
-
-# move to the debian packaging branch
-if ! git checkout deb-packaging; then
-  echo "\033[0;31mERROR: Unable to checkout the 'deb-packaging' branch. Does it exist?\033[0m" && exit 1
+# Install additional dependencies if provided
+if [ -n "$INPUT_DEPENDENCIES" ]; then
+  DEPS="$INPUT_DEPENDENCIES"
+  sudo apt-get -qq update
+  sudo apt-get -qq dist-upgrade
+  sudo apt-get install --no-install-recommends -qq $DEPS
 fi
-
-sudo apt-get -qq update
-sudo apt-get -qq dist-upgrade
-sudo apt-get --no-install-recommends -qq build-dep .
-
-echo -e "\n\033[1;32mInstalled all the build dependencies!\033[0m\n"
 
 #---------------------------------#
 # Update the translation template #
 #---------------------------------#
 
-# point head back to what it was before checking out deb-packaging
-git checkout -
+# make sure we are in sync with HEAD
 git reset --hard HEAD
 
 if ! git checkout $TRANSLATION_BRANCH; then


### PR DESCRIPTION
Fixes #63

See demos:

- https://github.com/ryonakano/konbucase/commits/no-deb-packaging (a repo that has `deb-packaging` branch)
- https://github.com/ryonakano/louper/commits/no-deb-packaging (a repo that does not has `deb-packaging` branch)

things to consider:

* [ ] how to handle specified version like `libhandy1-dev (>= 0.99)`?
