### PR TITLE
gettext: Use different commit message when regenerate_po is enabled

### DIFF
--- a/gettext-template/check-diff.py
+++ b/gettext-template/check-diff.py
@@ -6,16 +6,15 @@ import io
 def commit_to_repo(repo):
     print('There are translation changes, committing changes to repository!')
     files = repo.git.diff(None, name_only=True)
+    has_po=False
     for f in files.split('\n'):
-        if f.endswith ('.po'):
+        if f.endswith('.po'):
             has_po=True
             repo.git.add(f)
-        elif f.endswith ('.pot'):
+        elif f.endswith('.pot'):
             repo.git.add(f)
-    if has_po:
-        repo.git.commit('-m', 'Update translation files')
-    else:
-        repo.git.commit('-m', 'Update translation template')
+    commit_message = 'Update translation files' if has_po else 'Update translation template'
+    repo.git.commit('-m', commit_message)
     infos = repo.remotes.origin.push()
     has_error=False
     error_msg=''

--- a/gettext-template/check-diff.py
+++ b/gettext-template/check-diff.py
@@ -7,9 +7,15 @@ def commit_to_repo(repo):
     print('There are translation changes, committing changes to repository!')
     files = repo.git.diff(None, name_only=True)
     for f in files.split('\n'):
-        if f.endswith ('.po') or f.endswith ('.pot'):
+        if f.endswith ('.po'):
+            has_po=True
             repo.git.add(f)
-    repo.git.commit('-m', 'Update translation template')
+        elif f.endswith ('.pot'):
+            repo.git.add(f)
+    if has_po:
+        repo.git.commit('-m', 'Update translation files')
+    else:
+        repo.git.commit('-m', 'Update translation template')
     infos = repo.remotes.origin.push()
     has_error=False
     error_msg=''


### PR DESCRIPTION
The commit message is "Update translation template" even if `regenerate_po` option is enabled, which means the updated files are `.pot` and `.po`. The word "translation template" only means `.pot` files, so we should update the copy here
