### PR TITLE
Add Debian Changelog Release Channel Variable

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -14,6 +14,13 @@ This image is intended for use with elementary debian projects. There are a few 
 
 In order to create tags and push changes to various branches, the script needs a github token. Keep in mind, when using github workflows, the virtual environment [automatically comes with a generated github token secret](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret).
 
+To change the debian release channel in the project's debian changelog config, you can set the `RELEASE_CHANNEL` environment variable:
+
+```yaml
+env:
+  RELEASE_CHANNEL: focal
+```
+
 ### Specifying a release branch name
 
 By default, this action will create and update a branch named 'stable' whenever a release is pushed. The branch name can be set via the `release_branch` input. Example:

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -10,6 +10,10 @@ if [ -z "${GITHUB_TOKEN}" ]; then
   echo "\033[0;31mERROR: The GITHUB_TOKEN environment variable is not defined.\033[0m"  && exit 1
 fi
 
+if [ -z "${RELEASE_CHANNEL}" ]; then
+  RELEASE_CHANNEL="focal"
+fi
+
 if [ -z "$1" ]; then
   RELEASE_BRANCH="stable"
 else
@@ -118,7 +122,7 @@ else
 fi
 
 # Set the release channel/distro
-dch -Mr bionic
+dch -Mr "$RELEASE_CHANNEL"
 
 # Commit, Tag, and Push
 TAG="$VERSION-debian"


### PR DESCRIPTION
__CHANGES:__

* Allow the debian changelog release channel to be configured via environment variables.
* Set the default value to `focal`

closes #58 