### PR TITLE
Fix authorization token "Bad Credentials"

### DIFF
--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -74,7 +74,7 @@ DATA="
 "
 
 # push the release content to github!
-if ! curl -H 'Authorization: token $GITHUB_TOKEN' --data "$DATA" https://api.github.com/repos/"$GITHUB_REPOSITORY"/releases; then
+if ! curl -X POST https://api.github.com/repos/"$GITHUB_REPOSITORY"/releases -H "authorization: Bearer $GITHUB_TOKEN" -H 'content-type: application/json' --data "$DATA"; then
   echo "\033[0;31mERROR: Unable to post github release tag information!\033[0m"  && exit 1
 fi
 echo -e "\n\033[1;32mA new github release tag has been created!\033[0m\n"

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -74,7 +74,7 @@ DATA="
 "
 
 # push the release content to github!
-if ! curl -X POST https://api.github.com/repos/"$GITHUB_REPOSITORY"/releases -H "authorization: Bearer $GITHUB_TOKEN" -H 'content-type: application/json' --data "$DATA"; then
+if ! curl -X POST https://api.github.com/repos/"$GITHUB_REPOSITORY"/releases -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" --data "$DATA"; then
   echo "\033[0;31mERROR: Unable to post github release tag information!\033[0m"  && exit 1
 fi
 echo -e "\n\033[1;32mA new github release tag has been created!\033[0m\n"


### PR DESCRIPTION
Following the official [Github REST api Documentation](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#authentication), this explicitly sets the api to use the v3 rest endpoint. It also uses double quotes for the authorization token entry, since single quotes don't expand variables. 