### PR TITLE
gettext-template: Fix git issue with /github/workspace being unsafe

### DIFF
--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -35,6 +35,7 @@ echo "Setting up git credentials..."
 git remote set-url origin https://x-access-token:"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git
 git config --global user.email "$GIT_USER_EMAIL"
 git config --global user.name "$GIT_USER_NAME"
+git config --global --add safe.directory /github/workspace
 echo "Git credentials configured."
 
 # get the project's name:


### PR DESCRIPTION
As a CVE https://github.blog/2022-04-12-git-security-vulnerability-announced/
mitigation has been introduced in git, the GitHub actions need to be set as
unsafe by default for now.