### PR TITLE
Add /github/workspace to safe.directory

### DIFF
--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -33,6 +33,7 @@ echo "Setting up git credentials..."
 git remote set-url origin https://x-access-token:"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git
 git config --global user.email "$GIT_USER_EMAIL"
 git config --global user.name "$GIT_USER_NAME"
+git config --global --add safe.directory /github/workspace
 echo "Git credentials configured."
 
 # get the project's name:

--- a/release/entrypoint.sh
+++ b/release/entrypoint.sh
@@ -10,6 +10,9 @@ if [ -z "${GITHUB_TOKEN}" ]; then
   echo "\033[0;31mERROR: The GITHUB_TOKEN environment variable is not defined.\033[0m"  && exit 1
 fi
 
+# Git repository is owned by another user, mark it as safe
+git config --global --add safe.directory /github/workspace
+
 if [ -z "${RELEASE_CHANNEL}" ]; then
   RELEASE_CHANNEL="focal"
 fi
@@ -33,7 +36,6 @@ echo "Setting up git credentials..."
 git remote set-url origin https://x-access-token:"$GITHUB_TOKEN"@github.com/"$GITHUB_REPOSITORY".git
 git config --global user.email "$GIT_USER_EMAIL"
 git config --global user.name "$GIT_USER_NAME"
-git config --global --add safe.directory /github/workspace
 echo "Git credentials configured."
 
 # get the project's name:


### PR DESCRIPTION
We're getting a "dubious ownership" issue with all release actions now, likely due to a security policy change in GitHub?

https://github.com/elementary/switchboard-plug-keyboard/actions/runs/3848743242/jobs/6556908493
https://github.com/elementary/feedback/actions/runs/3848744986/jobs/6556911274