### PR TITLE
gettext-template: Generate AppStream language completion percentages

### DIFF
--- a/gettext-template/Dockerfile
+++ b/gettext-template/Dockerfile
@@ -3,11 +3,10 @@ FROM elementary/docker:${ELEMENTARY_CODENAME}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -qq update && apt-get install -qq meson git python3-git libxml2-utils appstream policykit-1 sudo
+RUN apt-get -qq update && apt-get install -qq meson git python3-git libxml2-utils appstream policykit-1 sudo translate-toolkit
 
 RUN groupadd -r elementary && useradd --no-log-init -r -g elementary elementary
 
-COPY entrypoint.sh /entrypoint.sh
-COPY check-diff.py /check-diff.py
+COPY entrypoint.sh check-diff.py update-appstream-percentages.py /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/gettext-template/README.md
+++ b/gettext-template/README.md
@@ -54,6 +54,7 @@ If you specify the path to your AppStream XML file, this action will add the `<l
 
 ```xml
   <languages>
+    <lang percentage="100">en</lang>
     <lang percentage="78">en_GB</lang>
     <lang percentage="85">ja</lang>
     <lang percentage="80">uk</lang>

--- a/gettext-template/README.md
+++ b/gettext-template/README.md
@@ -48,6 +48,33 @@ with:
   regenerate_po: 'true'
 ```
 
+### Updating AppStream completion percentages
+
+If you specify the path to your AppStream XML file, this action will add the `<languages>` section with details about the percentage completion of each translation. Example:
+
+```xml
+  <languages>
+    <lang percentage="78">en_GB</lang>
+    <lang percentage="85">ja</lang>
+    <lang percentage="80">uk</lang>
+  </languages>
+```
+
+To configure this, do the following:
+
+```yaml
+with:
+  appstream_file: 'data/appcenter.metainfo.xml.in'
+```
+
+**Note:** This action assumes that the native language of the application is English (en) by default, and sets the translation percentage of that language to 100%. if this is not the case, you can change the native language as follows:
+
+```yaml
+with:
+  appstream_file: 'data/appcenter.metainfo.xml.in'
+  native_language: 'de'
+```
+
 ## Examples
 
 ### Simple Example

--- a/gettext-template/action.yml
+++ b/gettext-template/action.yml
@@ -10,6 +10,13 @@ inputs:
   regenerate_po:
     description: 'Also regenerate the .po files'
     required: false
+  appstream_file:
+    description: 'The path to the AppStream XML file to be updated with translation completion percentages if specified'
+    required: false
+  native_language:
+    description: 'The native language to be specified as 100% complete in the AppStream file if specified'
+    required: false
+    default: 'en'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/gettext-template/check-diff.py
+++ b/gettext-template/check-diff.py
@@ -10,6 +10,13 @@ def commit_to_repo(repo):
         if f.endswith ('.po') or f.endswith ('.pot'):
             repo.git.add(f)
     repo.git.commit('-m', 'Update translation template')
+
+    files = repo.git.diff(None, name_only=True)
+    for f in files.split('\n'):
+        if ".xml" in f:
+            repo.git.add(f)
+    repo.git.commit('-m', 'Update AppStream translation percentages')
+
     infos = repo.remotes.origin.push()
     has_error=False
     error_msg=''
@@ -27,7 +34,7 @@ files = repo.git.diff(None, name_only=True)
 needs_commit=False
 
 for f in files.split('\n'):
-    if f.endswith ('.pot'):
+    if f.endswith ('.pot') or ".xml" in f:
         raw_diff = repo.git.diff(t, f)
         output = io.StringIO()
         for line in raw_diff.splitlines():

--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -84,5 +84,10 @@ GETTEXT_TARGETS=$(git ls-files | grep \.pot$ | sed 's/.*\///' | sed 's/.pot/-pot
 fi
 ninja -C build $GETTEXT_TARGETS
 echo -e "\n\033[1;32mSuccessfully build the project!\033[0m\n"
+
+if [ -n "${INPUT_APPSTREAM_FILE}" ]; then
+  python3 /update-appstream-percentages.py "${INPUT_APPSTREAM_FILE}" --native-language "${INPUT_NATIVE_LANGUAGE}"
+fi
+
 python3 /check-diff.py
 

--- a/gettext-template/update-appstream-percentages.py
+++ b/gettext-template/update-appstream-percentages.py
@@ -1,0 +1,45 @@
+from translate.storage import factory
+import lxml.etree as etree
+import argparse
+import glob
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('file', type=argparse.FileType('r'))
+argparser.add_argument('--native-language', default='en')
+args = argparser.parse_args()
+
+po_files = glob.glob("po/*.po")
+lang_keys = [filename.replace("po/", "").replace(".po", "")
+             for filename in po_files]
+
+completion_map = {args.native_language: "100"}
+
+def percent(denominator, divisor):
+    if divisor == 0:
+        return 0
+    else:
+        return denominator * 100 / divisor
+
+
+for key in lang_keys:
+    try:
+        store = factory.getobject(f"po/{key}.po")
+    except ValueError as e:
+        continue
+
+    units = [unit for unit in store.units if unit.source]
+    translated = [unit for unit in store.units if unit.istranslated()]
+
+    completion_map[key] = round(percent(len(translated), len(units)))
+
+appstream_tree = etree.parse(args.file)
+appstream_root = appstream_tree.getroot()
+for elem in appstream_root.findall("languages"):
+    elem.getparent().remove(elem)
+
+languages = etree.SubElement(appstream_root, "languages")
+for k, v in completion_map.items():
+    etree.SubElement(languages, "lang", {"percentage": str(v)}).text = k
+
+etree.indent(appstream_root)
+appstream_tree.write(args.file.name, encoding="utf-8", xml_declaration=True, pretty_print=True)

--- a/gettext-template/update-appstream-percentages.py
+++ b/gettext-template/update-appstream-percentages.py
@@ -12,7 +12,7 @@ po_files = glob.glob("po/*.po")
 lang_keys = [filename.replace("po/", "").replace(".po", "")
              for filename in po_files]
 
-completion_map = {args.native_language: "100"}
+completion_map = {}
 
 
 def percent(denominator, divisor):
@@ -32,6 +32,8 @@ for key in lang_keys:
     translated = [unit for unit in store.units if unit.istranslated()]
 
     completion_map[key] = round(percent(len(translated), len(units)))
+
+completion_map[args.native_language] = "100"
 
 appstream_tree = etree.parse(args.file)
 appstream_root = appstream_tree.getroot()

--- a/gettext-template/update-appstream-percentages.py
+++ b/gettext-template/update-appstream-percentages.py
@@ -14,6 +14,7 @@ lang_keys = [filename.replace("po/", "").replace(".po", "")
 
 completion_map = {args.native_language: "100"}
 
+
 def percent(denominator, divisor):
     if divisor == 0:
         return 0
@@ -27,7 +28,7 @@ for key in lang_keys:
     except ValueError as e:
         continue
 
-    units = [unit for unit in store.units if unit.source]
+    units = [unit for unit in store.units if unit.istranslatable()]
     translated = [unit for unit in store.units if unit.istranslated()]
 
     completion_map[key] = round(percent(len(translated), len(units)))
@@ -42,4 +43,5 @@ for k, v in completion_map.items():
     etree.SubElement(languages, "lang", {"percentage": str(v)}).text = k
 
 etree.indent(appstream_root)
-appstream_tree.write(args.file.name, encoding="utf-8", xml_declaration=True, pretty_print=True)
+appstream_tree.write(args.file.name, encoding="utf-8",
+                     xml_declaration=True, pretty_print=True)


### PR DESCRIPTION
Optionally populates the `<languages>` section of the AppStream XML with completion percentages for each language.

Generated difference to AppStream file can be seen here:
https://github.com/elementary/appcenter/compare/master...davidmhewitt:appcenter:master#diff-6bf387a09e36b6c41f6f343febb411df189e9189e7db5eaeb3e7f74a2bb63ec4L217