### PR TITLE
gettext: Fix missing '-e' option for echo

### DIFF
--- a/gettext-template/entrypoint.sh
+++ b/gettext-template/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -n "$GIT_USER_TOKEN" ]; then
 fi
 
 if [ -z "${GITHUB_TOKEN}" ]; then
-  echo "\033[0;31mERROR: The GITHUB_TOKEN environment variable is not defined.\033[0m"  && exit 1
+  echo -e "\033[0;31mERROR: The GITHUB_TOKEN environment variable is not defined.\033[0m"  && exit 1
 fi
 
 # Git repository is owned by another user, mark it as safe
@@ -71,7 +71,7 @@ git checkout -
 git reset --hard HEAD
 
 if ! git checkout $TRANSLATION_BRANCH; then
-  echo "\033[0;31mERROR: Unable to checkout the '$TRANSLATION_BRANCH' branch. Does it exist?\033[0m" && exit 1
+  echo -e "\033[0;31mERROR: Unable to checkout the '$TRANSLATION_BRANCH' branch. Does it exist?\033[0m" && exit 1
 fi
 
 # update the translation template and push changes if required


### PR DESCRIPTION
This is the differences:

![スクリーンショット 2023-09-25 21 08 12](https://github.com/elementary/actions/assets/26003928/4e6feadf-87c9-4faf-bbd7-b55ed95ebf0c)
