### PR TITLE
gettext-flatpak: Fix only the last pot is updated

### DIFF
--- a/gettext-flatpak/README.md
+++ b/gettext-flatpak/README.md
@@ -44,8 +44,6 @@ jobs:
       image: ghcr.io/elementary/flatpak-platform/runtime:7.2-x86_64
       options: --privileged
     steps:
-
-    steps:
     - name: Install git, python3-git and jq
       run: |
         apt-get update

--- a/gettext-flatpak/README.md
+++ b/gettext-flatpak/README.md
@@ -44,6 +44,8 @@ jobs:
       image: ghcr.io/elementary/flatpak-platform/runtime:7.2-x86_64
       options: --privileged
     steps:
+
+    steps:
     - name: Install git, python3-git and jq
       run: |
         apt-get update

--- a/gettext-flatpak/entrypoint.sh
+++ b/gettext-flatpak/entrypoint.sh
@@ -47,9 +47,11 @@ flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --forc
 #---------------------------------#
 
 TRANSLATION_FILES=$(git ls-files | grep \.pot$)
+# echo with quotation marks for multiple translation templates
+GETTEXT_TARGETS=$(echo "$TRANSLATION_FILES" | sed 's/.*\///' | sed 's/.pot/-pot/')
+
+echo "ninja $GETTEXT_TARGETS" | flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --force-clean --build-shell="$MODULE_NAME" --state-dir="$TMPDIR"
 for TRANSLATION_FILE in $TRANSLATION_FILES; do
-    GETTEXT_TARGETS=$(echo $TRANSLATION_FILE | sed 's/.*\///' | sed 's/.pot/-pot/')
-    echo "ninja $GETTEXT_TARGETS" | flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --force-clean --build-shell="$MODULE_NAME" --state-dir="$TMPDIR"
     cp "$TMPDIR/build/$MODULE_NAME/$TRANSLATION_FILE" $TRANSLATION_FILE
 done
 

--- a/gettext-flatpak/entrypoint.sh
+++ b/gettext-flatpak/entrypoint.sh
@@ -47,8 +47,7 @@ flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --forc
 #---------------------------------#
 
 TRANSLATION_FILES=$(git ls-files | grep \.pot$)
-# echo with quotation marks for multiple translation templates
-GETTEXT_TARGETS=$(echo "$TRANSLATION_FILES" | sed 's/.*\///' | sed 's/.pot/-pot/')
+GETTEXT_TARGETS=$(echo $TRANSLATION_FILES | sed 's/\S*\///g' | sed 's/.pot/-pot/g')
 
 echo "ninja $GETTEXT_TARGETS" | flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --force-clean --build-shell="$MODULE_NAME" --state-dir="$TMPDIR"
 for TRANSLATION_FILE in $TRANSLATION_FILES; do

--- a/gettext-flatpak/entrypoint.sh
+++ b/gettext-flatpak/entrypoint.sh
@@ -47,10 +47,9 @@ flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --forc
 #---------------------------------#
 
 TRANSLATION_FILES=$(git ls-files | grep \.pot$)
-GETTEXT_TARGETS=$(echo $TRANSLATION_FILES | sed 's/.*\///' | sed 's/.pot/-pot/')
-
-echo "ninja $GETTEXT_TARGETS" | flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --force-clean --build-shell="$MODULE_NAME" --state-dir="$TMPDIR"
 for TRANSLATION_FILE in $TRANSLATION_FILES; do
+    GETTEXT_TARGETS=$(echo $TRANSLATION_FILE | sed 's/.*\///' | sed 's/.pot/-pot/')
+    echo "ninja $GETTEXT_TARGETS" | flatpak-builder build "$MANIFEST_PATH" --repo=repo --disable-rofiles-fuse --force-clean --build-shell="$MODULE_NAME" --state-dir="$TMPDIR"
     cp "$TMPDIR/build/$MODULE_NAME/$TRANSLATION_FILE" $TRANSLATION_FILE
 done
 


### PR DESCRIPTION
Fixes only the last pot file is updated when there are multiple pot files.

```bash
ryo@b760m:~/work/sgpthomas/hourglass$ TRANSLATION_FILES=$(git ls-files | grep \.pot$)
ryo@b760m:~/work/sgpthomas/hourglass$ echo $TRANSLATION_FILES
po/com.github.sgpthomas.hourglass.pot po/extra/extra.pot
ryo@b760m:~/work/sgpthomas/hourglass$ GETTEXT_TARGETS=$(echo $TRANSLATION_FILES | sed 's/\S*\///g' | sed 's/.pot/-pot/g')
ryo@b760m:~/work/sgpthomas/hourglass$ echo "ninja $GETTEXT_TARGETS"
ninja com.github.sgpthomas.hourglass-pot extra-pot
ryo@b760m:~/work/sgpthomas/hourglass$
```