### PR TITLE
Dockerfile: add apt-utils

### DIFF
--- a/gettext-template/Dockerfile
+++ b/gettext-template/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/elementary/docker:${ELEMENTARY_CODENAME}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -qq update && apt-get install -qq meson git python3-git libxml2-utils appstream policykit-1 sudo
+RUN apt-get -qq update && apt-get install -qq apt-utils meson git python3-git libxml2-utils appstream policykit-1 sudo
 
 RUN groupadd -r elementary && useradd --no-log-init -r -g elementary elementary
 


### PR DESCRIPTION
Gettext builds are failing because of debconf. Complaining about missing apt-utils https://github.com/elementary/switchboard-plug-applications/actions/runs/8443096481/job/23125952583

```debconf: delaying package configuration, since apt-utils is not installed```