### PR TITLE
gettext-flatpak: Follow rebase of flatpak-platform Docker image

### DIFF
--- a/gettext-flatpak/README.md
+++ b/gettext-flatpak/README.md
@@ -44,10 +44,9 @@ jobs:
       image: ghcr.io/elementary/flatpak-platform/runtime:8-x86_64
       options: --privileged
     steps:
-    - name: Install git, python3-git and jq
+    - name: Install GitPython
       run: |
-        apt-get update
-        apt-get install git jq python3-git -y
+        python3 -m pip install GitPython
     - name: Clone repository
       uses: actions/checkout@v4
       with:
@@ -74,10 +73,9 @@ jobs:
       image: ghcr.io/elementary/flatpak-platform/runtime:8-x86_64
       options: --privileged
     steps:
-    - name: Install git, python3-git and jq
+    - name: Install GitPython
       run: |
-        apt-get update
-        apt-get install git jq python3-git -y
+        python3 -m pip install GitPython
     - name: Clone repository
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Part of https://github.com/elementary/flatpak-platform/issues/236 (documentation fix)

See https://github.com/elementary/calculator/pull/303#issuecomment-4370637330 if this change really works.
